### PR TITLE
feat: redesign dashboard layout

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,25 +1,271 @@
+import Image from "next/image";
+import { Prompt } from "next/font/google";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { redirect } from "next/navigation";
-import { Box, Typography, Paper, Stack, Button } from "@mui/material";
+import {
+  Avatar,
+  Box,
+  Divider,
+  IconButton,
+  List,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  ListSubheader,
+  Paper,
+  Stack,
+  Typography,
+} from "@mui/material";
+import type { SvgIconComponent } from "@mui/icons-material";
+import DashboardOutlinedIcon from "@mui/icons-material/DashboardOutlined";
+import AssignmentTurnedInOutlinedIcon from "@mui/icons-material/AssignmentTurnedInOutlined";
+import ReceiptLongOutlinedIcon from "@mui/icons-material/ReceiptLongOutlined";
+import LocalShippingOutlinedIcon from "@mui/icons-material/LocalShippingOutlined";
+import Inventory2OutlinedIcon from "@mui/icons-material/Inventory2Outlined";
+import AnalyticsOutlinedIcon from "@mui/icons-material/AnalyticsOutlined";
+import ManageSearchOutlinedIcon from "@mui/icons-material/ManageSearchOutlined";
+import SettingsSuggestOutlinedIcon from "@mui/icons-material/SettingsSuggestOutlined";
+import GroupsOutlinedIcon from "@mui/icons-material/GroupsOutlined";
+import InventoryOutlinedIcon from "@mui/icons-material/InventoryOutlined";
+import LogoutOutlinedIcon from "@mui/icons-material/LogoutOutlined";
+import NotificationsNoneOutlinedIcon from "@mui/icons-material/NotificationsNoneOutlined";
+import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
+import SettingsOutlinedIcon from "@mui/icons-material/SettingsOutlined";
+
+const prompt = Prompt({
+  weight: ["400", "500", "600", "700"],
+  subsets: ["thai", "latin"],
+});
+
+type NavItem = {
+  label: string;
+  icon: SvgIconComponent;
+  active?: boolean;
+};
+
+const navigationSections: Array<{
+  title: string;
+  items: NavItem[];
+}> = [
+  {
+    title: "รายการ",
+    items: [
+      { label: "รายการขอซ่อม", icon: DashboardOutlinedIcon, active: true },
+      { label: "รายการสั่งผลิต", icon: AssignmentTurnedInOutlinedIcon },
+      { label: "รายการขาย", icon: ReceiptLongOutlinedIcon },
+      { label: "รายการจัดส่ง", icon: LocalShippingOutlinedIcon },
+      { label: "รายการรับวัตถุดิบ", icon: Inventory2OutlinedIcon },
+    ],
+  },
+  {
+    title: "รายงาน",
+    items: [
+      { label: "รายงานการขาย", icon: AnalyticsOutlinedIcon },
+      { label: "รายงานการตรวจสอบ", icon: ManageSearchOutlinedIcon },
+      { label: "รายงานระบบ", icon: SettingsSuggestOutlinedIcon },
+      { label: "รายงานการผลิต", icon: InventoryOutlinedIcon },
+    ],
+  },
+  {
+    title: "การจัดการ",
+    items: [
+      { label: "บัญชีผู้ใช้", icon: GroupsOutlinedIcon },
+      { label: "สินค้า", icon: Inventory2OutlinedIcon },
+      { label: "ตั้งค่าระบบ", icon: SettingsOutlinedIcon },
+    ],
+  },
+];
 
 export default async function DashboardPage() {
   const session = await getServerSession(authOptions);
   if (!session?.user) redirect("/login");
 
   return (
-    <Box sx={{ p: 3 }}>
-      <Typography variant="h4" fontWeight={700} mb={2}>Dashboard</Typography>
-      <Paper sx={{ p: 3 }}>
-        <Stack direction="row" justifyContent="space-between" alignItems="center">
-          <Typography>
-            สวัสดี {session.user?.name ?? "ผู้ใช้"} (role: {(session.user as any).role ?? "USER"})
+    <Box
+      component="main"
+      sx={{
+        minHeight: "100vh",
+        display: "flex",
+        backgroundColor: "#f1f1f1",
+        fontFamily: prompt.style.fontFamily,
+      }}
+    >
+      <Box
+        component="aside"
+        sx={{
+          width: { xs: 260, lg: 280 },
+          backgroundColor: "#8b1f1f",
+          color: "#fff",
+          display: "flex",
+          flexDirection: "column",
+          py: 4,
+          px: 2,
+          gap: 4,
+        }}
+      >
+        <Stack spacing={2} alignItems="center">
+          <Box
+            sx={{
+              width: 120,
+              height: 120,
+              position: "relative",
+              borderRadius: 3,
+              backgroundColor: "#fff",
+              overflow: "hidden",
+              boxShadow: "0 8px 22px rgba(0,0,0,0.25)",
+            }}
+          >
+            <Image src="/images/logo.png" alt="อาวินี่ใหญ่" fill sizes="120px" />
+          </Box>
+          <Typography variant="h6" fontWeight={700} textAlign="center">
+            อาวินี่ใหญ่
           </Typography>
-          <form action="/api/auth/signout" method="post">
-            <Button type="submit" variant="outlined">ออกจากระบบ</Button>
-          </form>
         </Stack>
-      </Paper>
+
+        <List
+          subheader={false}
+          sx={{
+            px: 1,
+            "& .MuiListSubheader-root": {
+              color: "#ffebee",
+              fontWeight: 600,
+              fontSize: "0.95rem",
+              lineHeight: 1.6,
+            },
+          }}
+        >
+          {navigationSections.map((section) => (
+            <Box key={section.title} sx={{ mb: 3 }}>
+              <ListSubheader component="div" disableSticky sx={{ px: 0 }}>
+                {section.title}
+              </ListSubheader>
+              {section.items.map((item) => {
+                const Icon = item.icon;
+                return (
+                  <ListItemButton
+                    key={item.label}
+                    selected={item.active}
+                    sx={{
+                      borderRadius: 2,
+                      mb: 0.5,
+                      color: "inherit",
+                      "&.Mui-selected": {
+                        backgroundColor: "rgba(255, 255, 255, 0.14)",
+                        "&:hover": {
+                          backgroundColor: "rgba(255, 255, 255, 0.22)",
+                        },
+                      },
+                    }}
+                  >
+                    <ListItemIcon sx={{ color: "inherit", minWidth: 36 }}>
+                      <Icon fontSize="small" />
+                    </ListItemIcon>
+                    <ListItemText
+                      primary={item.label}
+                      primaryTypographyProps={{ fontWeight: item.active ? 600 : 500 }}
+                    />
+                  </ListItemButton>
+                );
+              })}
+            </Box>
+          ))}
+        </List>
+
+        <Box sx={{ flexGrow: 1 }} />
+
+        <Divider sx={{ borderColor: "rgba(255,255,255,0.2)", my: 2 }} />
+
+        <Stack spacing={1} alignItems="center">
+          <Avatar
+            alt={session.user?.name ?? "ผู้ใช้"}
+            sx={{ width: 64, height: 64, bgcolor: "rgba(0,0,0,0.2)" }}
+          >
+            {session.user?.name?.[0] ?? "ผ"}
+          </Avatar>
+          <Typography fontWeight={600}>{session.user?.name ?? "ผู้ใช้"}</Typography>
+          <Typography variant="body2" sx={{ opacity: 0.7 }}>
+            {session.user?.role ?? "USER"}
+          </Typography>
+        </Stack>
+      </Box>
+
+      <Box
+        sx={{
+          flexGrow: 1,
+          display: "flex",
+          flexDirection: "column",
+          backgroundColor: "#fafafa",
+        }}
+      >
+        <Box
+          component="header"
+          sx={{
+            backgroundColor: "#8b1f1f",
+            color: "#fff",
+            px: { xs: 3, md: 5 },
+            py: 2,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: 2,
+          }}
+        >
+          <Stack spacing={0.5}>
+            <Typography variant="h5" fontWeight={700}>
+              รายการขอซ่อม
+            </Typography>
+            <Typography variant="body2" sx={{ opacity: 0.85 }}>
+              เลือกรายการตามระบบย่อยที่ต้องการตรวจสอบได้ที่เมนูด้านซ้าย
+            </Typography>
+          </Stack>
+
+          <Stack direction="row" spacing={1} alignItems="center">
+            <IconButton size="small" sx={{ color: "inherit" }}>
+              <HelpOutlineOutlinedIcon />
+            </IconButton>
+            <IconButton size="small" sx={{ color: "inherit" }}>
+              <NotificationsNoneOutlinedIcon />
+            </IconButton>
+            <IconButton size="small" sx={{ color: "inherit" }}>
+              <SettingsOutlinedIcon />
+            </IconButton>
+            <form action="/api/auth/signout" method="post">
+              <IconButton type="submit" size="small" sx={{ color: "inherit" }}>
+                <LogoutOutlinedIcon />
+              </IconButton>
+            </form>
+          </Stack>
+        </Box>
+
+        <Box sx={{ flexGrow: 1, p: { xs: 3, md: 5 } }}>
+          <Paper
+            elevation={0}
+            sx={{
+              borderRadius: 4,
+              minHeight: 360,
+              backgroundColor: "#fff",
+              border: "1px solid #f0f0f0",
+              p: { xs: 3, md: 5 },
+              display: "flex",
+              flexDirection: "column",
+              justifyContent: "center",
+              alignItems: "center",
+              textAlign: "center",
+              color: "#4b4b4b",
+              gap: 2,
+            }}
+          >
+            <Typography variant="h4" fontWeight={700} color="#8b1f1f">
+              ระบบงานซ่อมบำรุง
+            </Typography>
+            <Typography maxWidth={480}>
+              โปรดเลือกรายการงานซ่อมจากเมนูด้านซ้ายเพื่อเริ่มต้นตรวจสอบรายละเอียด
+              และจัดการสถานะการดำเนินงานของทีมซ่อมบำรุง
+            </Typography>
+          </Paper>
+        </Box>
+      </Box>
     </Box>
   );
 }

--- a/next-auth.d.ts
+++ b/next-auth.d.ts
@@ -1,0 +1,22 @@
+import type { DefaultSession, DefaultUser } from "next-auth";
+import type { JWT as DefaultJWT } from "next-auth/jwt";
+
+declare module "next-auth" {
+  interface Session {
+    user?: DefaultSession["user"] & {
+      id?: string;
+      role?: string | null;
+    };
+  }
+
+  interface User extends DefaultUser {
+    role?: string | null;
+  }
+}
+
+declare module "next-auth/jwt" {
+  interface JWT extends DefaultJWT {
+    id?: string;
+    role?: string | null;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@mui/material": "^7.3.2",
+    "@mui/icons-material": "^7.3.2",
     "@next-auth/prisma-adapter": "^1.0.7",
     "@prisma/client": "^6.16.2",
     "bcrypt": "^6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@emotion/styled':
         specifier: ^11.14.1
         version: 11.14.1(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.0))(@types/react@19.1.13)(react@19.1.0)
+      '@mui/icons-material':
+        specifier: ^7.3.2
+        version: 7.3.2(@mui/material@7.3.2(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.0))(@types/react@19.1.13)(react@19.1.0))(@types/react@19.1.13)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@types/react@19.1.13)(react@19.1.0)
       '@mui/material':
         specifier: ^7.3.2
         version: 7.3.2(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.0))(@types/react@19.1.13)(react@19.1.0))(@types/react@19.1.13)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -537,6 +540,17 @@ packages:
 
   '@mui/core-downloads-tracker@7.3.2':
     resolution: {integrity: sha512-AOyfHjyDKVPGJJFtxOlept3EYEdLoar/RvssBTWVAvDJGIE676dLi2oT/Kx+FoVXFoA/JdV7DEMq/BVWV3KHRw==}
+
+  '@mui/icons-material@7.3.2':
+    resolution: {integrity: sha512-TZWazBjWXBjR6iGcNkbKklnwodcwj0SrChCNHc9BhD9rBgET22J1eFhHsEmvSvru9+opDy3umqAimQjokhfJlQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@mui/material': ^7.3.2
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@mui/material@7.3.2':
     resolution: {integrity: sha512-qXvbnawQhqUVfH1LMgMaiytP+ZpGoYhnGl7yYq2x57GYzcFL/iPzSZ3L30tlbwEjSVKNYcbiKO8tANR1tadjUg==}
@@ -2649,6 +2663,14 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   '@mui/core-downloads-tracker@7.3.2': {}
+
+  '@mui/icons-material@7.3.2(@mui/material@7.3.2(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.0))(@types/react@19.1.13)(react@19.1.0))(@types/react@19.1.13)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@types/react@19.1.13)(react@19.1.0)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@mui/material': 7.3.2(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.0))(@types/react@19.1.13)(react@19.1.0))(@types/react@19.1.13)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.13
 
   '@mui/material@7.3.2(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.0))(@types/react@19.1.13)(react@19.1.0))(@types/react@19.1.13)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:


### PR DESCRIPTION
## Summary
- redesign the dashboard to match the red sidebar layout shown in the mockup, including navigation sections and top actions
- add Prompt font, icons, and session-powered profile details for a polished authenticated view
- declare NextAuth type augmentations and remove `any` casts for user role handling

## Testing
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68d9f5093c1483239f5dce04ee72a0e9