### PR TITLE
Finalize sales order approval workflow

### DIFF
--- a/app/api/sales/orders/[orderId]/approve/route.ts
+++ b/app/api/sales/orders/[orderId]/approve/route.ts
@@ -4,6 +4,8 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { hasPermission } from "@/lib/permissions";
 import { buildSaleOrderVisibilityWhere } from "@/lib/sales-visibility";
+import { mapWorkflowStatusToBaseStatus, shouldCommitStock } from "@/lib/sales-approval";
+import { rebuildOrderStockCommit } from "@/lib/sale-order-stock";
 
 export const runtime = "nodejs";
 
@@ -18,27 +20,61 @@ export async function POST(_req: NextRequest, context: { params: Promise<{ order
 
     const updated = await prisma.$transaction(async (tx) => {
       const scopeWhere = await buildSaleOrderVisibilityWhere();
-      const exists = await tx.saleOrder.findFirst({ where: { id: orderId, ...(scopeWhere as any) } });
+      const exists = await tx.saleOrder.findFirst({
+        where: { id: orderId, ...(scopeWhere as any) },
+      });
       if (!exists || (exists as any).deletedAt) throw new Error("NOT_FOUND");
 
-      const status = String((exists as any).status || "");
-      if (status === "CANCELLED") throw new Error("LOCKED");
-      if (status === "SHIPPED") throw new Error("LOCKED");
-      if (status !== "CONFIRMED" && status !== "DRAFT") throw new Error("INVALID_STATE");
+      const prevWorkflow = String((exists as any).workflowStatus ?? "DRAFT");
+      if (["CANCELLED", "REJECTED", "EXPIRED"].includes(prevWorkflow)) {
+        throw new Error("LOCKED");
+      }
+      if (["WAITING_PAYMENT_CONFIRMATION", "APPROVED", "AUTO_APPROVED", "SHIPPED"].includes(prevWorkflow)) {
+        throw new Error("INVALID_STATE");
+      }
 
-      // ตรวจสอบว่า user id ใน session มีอยู่จริงในตาราง User เพื่อเลี่ยง FK violation
+      const paymentCondition =
+        ((exists as any).paymentCondition as any) ?? "PREPAID";
+      const nextWorkflow =
+        paymentCondition === "PREPAID"
+          ? "WAITING_PAYMENT_CONFIRMATION"
+          : "APPROVED";
+      const nextBaseStatus = mapWorkflowStatusToBaseStatus(nextWorkflow as any);
+      const shouldApply = shouldCommitStock(nextWorkflow as any);
+
       const actorId = session?.user?.id as string | undefined;
-      const actor = actorId ? await tx.user.findUnique({ where: { id: actorId }, select: { id: true } }) : null;
+      const actor = actorId
+        ? await tx.user.findUnique({ where: { id: actorId }, select: { id: true } })
+        : null;
 
       const order = await tx.saleOrder.update({
         where: { id: orderId },
         data: {
-          status: "APPROVED" as any,
+          status: nextBaseStatus as any,
+          workflowStatus: nextWorkflow as any,
+          autoApprovedBySystem: false,
           approvedAt: new Date(),
           approvedByUserId: actor?.id ?? null,
+          creditEvaluationNote:
+            paymentCondition === "PREPAID"
+              ? "ผู้จัดการอนุมัติแล้ว รอตรวจสอบการชำระเงิน"
+              : "ผู้จัดการอนุมัติแล้ว",
         },
-        include: { items: true, reservations: true },
+        include: { items: true },
       });
+
+      if (shouldApply) {
+        await rebuildOrderStockCommit(tx as any, {
+          id: order.id,
+          shippingDate: order.shippingDate,
+          items: order.items.map((it: any) => ({
+            id: it.id,
+            productId: it.productId ?? null,
+            qty: it.qty ?? 0,
+          })),
+        });
+      }
+
       return order;
     });
 

--- a/app/api/sales/orders/[orderId]/cancel/route.ts
+++ b/app/api/sales/orders/[orderId]/cancel/route.ts
@@ -4,27 +4,10 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { hasPermission } from "@/lib/permissions";
 import { buildSaleOrderVisibilityWhere } from "@/lib/sales-visibility";
+import { mapWorkflowStatusToBaseStatus } from "@/lib/sales-approval";
+import { releaseOrderReservations } from "@/lib/sale-order-stock";
 
 export const runtime = "nodejs";
-
-async function releaseReservations(tx: any, saleOrderId: string) {
-  const reservations = await (tx as any).saleOrderStockReservation.findMany({
-    where: { saleOrderId, releasedAt: null, deletedAt: null },
-  });
-
-  for (const r of reservations as any[]) {
-    const stock = await tx.stock.findUnique({ where: { id: r.stockId }, select: { qtyReserved: true } });
-    const current = Number(stock?.qtyReserved ?? 0);
-    const qty = Math.max(0, Math.floor(Number(r.qty ?? 0)));
-    const releaseQty = Math.min(current, qty);
-    if (releaseQty > 0) {
-      await tx.stock.update({ where: { id: r.stockId }, data: { qtyReserved: { decrement: releaseQty } } });
-      const p = await tx.stock.findUnique({ where: { id: r.stockId }, select: { productId: true } });
-      await (tx as any).stockMovement.create({ data: { stockId: r.stockId, productId: p?.productId as string, saleOrderId: saleOrderId, type: 'RELEASE', qty: releaseQty } });
-    }
-    await (tx as any).saleOrderStockReservation.update({ where: { id: r.id }, data: { releasedAt: new Date() } });
-  }
-}
 
 export async function POST(req: NextRequest, context: { params: Promise<{ orderId: string }> }) {
   const { orderId } = await context.params;
@@ -48,10 +31,16 @@ export async function POST(req: NextRequest, context: { params: Promise<{ orderI
         throw new Error("NOT_FOUND");
       }
 
-      await releaseReservations(tx, orderId);
+      const prevWorkflow = String((order as any).workflowStatus ?? "DRAFT");
+      if (["CANCELLED", "REJECTED", "EXPIRED", "SHIPPED"].includes(prevWorkflow)) {
+        throw new Error("LOCKED");
+      }
+
+      await releaseOrderReservations(tx as any, orderId);
 
       // If order had shippingDate OR status is SHIPPED (treated as issued), return qtyOnHand back
-      if ((order as any).shippingDate || (order as any).status === "SHIPPED") {
+      const baseStatus = mapWorkflowStatusToBaseStatus(prevWorkflow as any);
+      if ((order as any).shippingDate || baseStatus === "SHIPPED") {
         const items = await tx.saleOrderItem.findMany({ where: { saleOrderId: orderId } });
         for (const item of items as any[]) {
           if (!item.productId || !item.qty) continue;
@@ -72,10 +61,20 @@ export async function POST(req: NextRequest, context: { params: Promise<{ orderI
         }
       }
 
+      const workflowStatus = "CANCELLED";
+      const status = mapWorkflowStatusToBaseStatus(workflowStatus as any);
+
       const updated = await tx.saleOrder.update({
         where: { id: orderId },
-        data: { status: "CANCELLED" as any, cancelReason, approvedAt: null, approvedByUserId: null },
-        include: { items: true, reservations: true },
+        data: {
+          status: status as any,
+          workflowStatus: workflowStatus as any,
+          cancelReason,
+          approvedAt: null,
+          approvedByUserId: null,
+          autoApprovedBySystem: false,
+        },
+        include: { items: true },
       });
       return updated;
     });
@@ -84,6 +83,9 @@ export async function POST(req: NextRequest, context: { params: Promise<{ orderI
   } catch (err) {
     if (err instanceof Error && err.message === "NOT_FOUND") {
       return NextResponse.json({ error: "ไม่พบใบสั่งขาย" }, { status: 404 });
+    }
+    if (err instanceof Error && err.message === "LOCKED") {
+      return NextResponse.json({ error: "เอกสารสถานะนี้ไม่สามารถยกเลิกได้" }, { status: 400 });
     }
     console.error("[POST /api/sales/orders/:id/cancel] error", err);
     return NextResponse.json({ error: "ยกเลิกใบสั่งขายไม่สำเร็จ" }, { status: 500 });

--- a/app/api/sales/orders/[orderId]/reject/route.ts
+++ b/app/api/sales/orders/[orderId]/reject/route.ts
@@ -4,27 +4,10 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { hasPermission } from "@/lib/permissions";
 import { buildSaleOrderVisibilityWhere } from "@/lib/sales-visibility";
+import { mapWorkflowStatusToBaseStatus } from "@/lib/sales-approval";
+import { releaseOrderReservations } from "@/lib/sale-order-stock";
 
 export const runtime = "nodejs";
-
-async function releaseReservations(tx: any, saleOrderId: string) {
-  const reservations = await (tx as any).saleOrderStockReservation.findMany({
-    where: { saleOrderId, releasedAt: null, deletedAt: null },
-  });
-
-  for (const r of reservations as any[]) {
-    const stock = await tx.stock.findUnique({ where: { id: r.stockId }, select: { qtyReserved: true } });
-    const current = Number(stock?.qtyReserved ?? 0);
-    const qty = Math.max(0, Math.floor(Number(r.qty ?? 0)));
-    const releaseQty = Math.min(current, qty);
-    if (releaseQty > 0) {
-      await tx.stock.update({ where: { id: r.stockId }, data: { qtyReserved: { decrement: releaseQty } } });
-      const p = await tx.stock.findUnique({ where: { id: r.stockId }, select: { productId: true } });
-      await (tx as any).stockMovement.create({ data: { stockId: r.stockId, productId: p?.productId as string, saleOrderId: saleOrderId, type: 'RELEASE', qty: releaseQty } });
-    }
-    await (tx as any).saleOrderStockReservation.update({ where: { id: r.id }, data: { releasedAt: new Date() } });
-  }
-}
 
 export async function POST(req: NextRequest, context: { params: Promise<{ orderId: string }> }) {
   const { orderId } = await context.params;
@@ -49,16 +32,27 @@ export async function POST(req: NextRequest, context: { params: Promise<{ orderI
         throw new Error("NOT_FOUND");
       }
 
-      const status = String((order as any).status || "");
-      if (status === "SHIPPED") throw new Error("LOCKED");
-      if (status === "CANCELLED") throw new Error("LOCKED");
+      const prevWorkflow = String((order as any).workflowStatus ?? "DRAFT");
+      if (["SHIPPED", "CANCELLED", "REJECTED", "EXPIRED"].includes(prevWorkflow)) {
+        throw new Error("LOCKED");
+      }
 
-      await releaseReservations(tx, orderId);
+      await releaseOrderReservations(tx as any, orderId);
+
+      const workflowStatus = "REJECTED";
+      const status = mapWorkflowStatusToBaseStatus(workflowStatus as any);
 
       const updated = await tx.saleOrder.update({
         where: { id: orderId },
-        data: { status: "CANCELLED" as any, rejectReason, approvedAt: null, approvedByUserId: null },
-        include: { items: true, reservations: true },
+        data: {
+          status: status as any,
+          workflowStatus: workflowStatus as any,
+          rejectReason,
+          approvedAt: null,
+          approvedByUserId: null,
+          autoApprovedBySystem: false,
+        },
+        include: { items: true },
       });
       return updated;
     });

--- a/app/api/sales/orders/[orderId]/route.ts
+++ b/app/api/sales/orders/[orderId]/route.ts
@@ -5,26 +5,17 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { hasPermission } from "@/lib/permissions";
 import { buildSaleOrderVisibilityWhere } from "@/lib/sales-visibility";
+import {
+  evaluateSaleOrderWorkflow,
+  mapWorkflowStatusToBaseStatus,
+  shouldCommitStock,
+} from "@/lib/sales-approval";
+import {
+  rebuildOrderStockCommit,
+  releaseOrderReservations,
+} from "@/lib/sale-order-stock";
 
 export const runtime = "nodejs";
-
-async function releaseReservations(tx: any, saleOrderId: string) {
-  const reservations = await (tx as any).saleOrderStockReservation.findMany({
-    where: { saleOrderId, releasedAt: null, deletedAt: null },
-  });
-
-  for (const r of reservations as any[]) {
-    const stock = await tx.stock.findUnique({ where: { id: r.stockId }, select: { qtyReserved: true } });
-    const current = Number(stock?.qtyReserved ?? 0);
-    const qty = Math.max(0, Math.floor(Number(r.qty ?? 0)));
-    const releaseQty = Math.min(current, qty);
-    if (releaseQty > 0) {
-      await tx.stock.update({ where: { id: r.stockId }, data: { qtyReserved: { decrement: releaseQty } } });
-      await (tx as any).stockMovement.create({ data: { stockId: r.stockId, productId: (await tx.stock.findUnique({ where: { id: r.stockId }, select: { productId: true } })).productId, saleOrderId: saleOrderId, type: 'RELEASE', qty: releaseQty } });
-    }
-    await (tx as any).saleOrderStockReservation.update({ where: { id: r.id }, data: { releasedAt: new Date() } });
-  }
-}
 
 export async function DELETE(_req: NextRequest, context: { params: Promise<{ orderId: string }> }) {
   const { orderId } = await context.params;
@@ -42,7 +33,7 @@ export async function DELETE(_req: NextRequest, context: { params: Promise<{ ord
         throw new Error("NOT_FOUND");
       }
 
-      await releaseReservations(tx, orderId);
+      await releaseOrderReservations(tx as any, orderId);
       // Soft delete via client extension
       await tx.saleOrder.delete({ where: { id: orderId } });
     });
@@ -106,6 +97,7 @@ const UpdateOrderSchema = z.object({
   shippingDate: z.string().datetime().optional(),
   creditTermDays: z.number().int().optional(),
   paymentCondition: z.enum(["PREPAID","POSTPAID"]).optional(),
+  upfrontPaymentPercent: z.number().min(0).max(100).optional().default(0),
   currency: z.string().default("THB"),
   vatIncluded: z.boolean().default(true),
   vatRate: z.number().min(0).default(7),
@@ -122,6 +114,22 @@ const UpdateOrderSchema = z.object({
   note: z.string().optional(),
   rejectReason: z.string().optional(),
   cancelReason: z.string().optional(),
+  workflowStatus: z
+    .enum([
+      "DRAFT",
+      "WAITING_MANAGER_APPROVAL",
+      "WAITING_PAYMENT_CONFIRMATION",
+      "WAITING_CREDIT_EXTENSION",
+      "AUTO_APPROVED",
+      "APPROVED",
+      "REJECTED",
+      "EXPIRED",
+      "PENDING_SHIPMENT",
+      "SHIPPED",
+      "CANCELLED",
+    ])
+    .optional(),
+  autoApprovedBySystem: z.boolean().optional(),
   items: z.array(OrderItemSchema).min(1),
 }).superRefine((val, ctx) => {
   if (val.usePromotion) {
@@ -166,170 +174,306 @@ export async function PUT(req: NextRequest, context: { params: Promise<{ orderId
     if (!hasPermission(perms, "sales", "edit")) {
       return NextResponse.json({ error: "ไม่มีสิทธิ์แก้ไขใบสั่งขาย" }, { status: 403 });
     }
+
     const json = await req.json();
     const parsed = UpdateOrderSchema.safeParse(json);
     if (!parsed.success) {
       return NextResponse.json({ error: "ข้อมูลไม่ถูกต้อง", issues: parsed.error.format() }, { status: 400 });
     }
+
     const data = parsed.data;
     const totals = computeTotals(data);
 
-    // Credit check when editing if payment condition is POSTPAID
-    try {
-      const existsHeader = await (prisma as any).saleOrder.findUnique({ where: { id: orderId }, select: { paymentCondition: true } });
-      const effectivePaymentCondition = (data as any).paymentCondition ?? (existsHeader?.paymentCondition ?? 'PREPAID');
-      if (effectivePaymentCondition === 'POSTPAID') {
-        const customer = await (prisma as any).customer.findUnique({ where: { id: data.customerId }, include: { dealerDetail: true } });
-        if (!customer) {
-          return NextResponse.json({ error: 'ไม่พบลูกค้า' }, { status: 400 });
-        }
-        const creditLimit = (customer as any)?.dealerDetail?.creditLimit as number | null | undefined;
-        if (typeof creditLimit === 'number') {
-          const relationshipScore = (customer as any)?.relationshipScore as number | null | undefined;
-          const enoughCredit = (totals.grandTotal ?? 0) <= creditLimit;
-          if (!enoughCredit) {
-            const canOverride = typeof relationshipScore === 'number' && relationshipScore > 3;
-            if (!canOverride) {
-              return NextResponse.json({ error: 'วงเงินเครดิตไม่พอ และคะแนนความสัมพันธ์ไม่ถึงเกณฑ์' }, { status: 400 });
-            }
-          }
-        }
-      }
-    } catch (checkErr) {
-      // If credit check fails unexpectedly, treat as server error
-      if (checkErr instanceof Response) return checkErr as any;
-      // fallthrough to continue; actual DB ops will run, but conservative approach would fail.
-    }
+    const scopeWhere = await buildSaleOrderVisibilityWhere();
 
     const updated = await prisma.$transaction(async (tx) => {
-      const scopeWhere = await buildSaleOrderVisibilityWhere();
-      const exists = await tx.saleOrder.findFirst({ where: { id: orderId, ...(scopeWhere as any) } });
+      const exists = await tx.saleOrder.findFirst({
+        where: { id: orderId, ...(scopeWhere as any) },
+      });
       if (!exists || (exists as any).deletedAt) throw new Error("NOT_FOUND");
-      if ((exists as any).status === "SHIPPED") throw new Error("LOCKED");
 
-      // Approval and status change gating
-      const prevStatus = String((exists as any).status || "");
-      const nextStatus = String((data as any).status ?? prevStatus);
-      const changingStatus = nextStatus !== prevStatus;
-      if (changingStatus) {
-        if (nextStatus === "APPROVED" && !hasPermission(perms, "sales", "approve")) {
-          throw new Error("NO_APPROVE");
+      const prevWorkflowStatus = String((exists as any).workflowStatus ?? "DRAFT");
+      const prevBaseStatus = mapWorkflowStatusToBaseStatus(prevWorkflowStatus as any);
+      if (["CANCELLED", "REJECTED", "EXPIRED"].includes(prevWorkflowStatus)) {
+        throw new Error("LOCKED");
+      }
+      if (prevBaseStatus === "SHIPPED") {
+        throw new Error("LOCKED");
+      }
+
+      let shippingLocked = Boolean((exists as any).shippingLocked);
+      let shippingUpdateCount = Number((exists as any).shippingUpdateCount ?? 0);
+
+      const prevShippingDate = exists.shippingDate
+        ? new Date(exists.shippingDate)
+        : null;
+      const shippingDateValue =
+        data.shippingDate !== undefined && data.shippingDate !== null
+          ? new Date(data.shippingDate)
+          : prevShippingDate;
+      const shippingDateChanged =
+        (prevShippingDate?.getTime() || 0) !== (shippingDateValue?.getTime() || 0);
+      if (shippingLocked && shippingDateChanged) {
+        throw new Error("SHIPPING_LOCKED");
+      }
+
+      const dueDateValue =
+        data.dueDate !== undefined && data.dueDate !== null
+          ? new Date(data.dueDate)
+          : exists.dueDate;
+      const expiresAt = dueDateValue ?? null;
+
+      const paymentCondition =
+        (data.paymentCondition as any) ??
+        ((exists as any).paymentCondition as any) ??
+        "PREPAID";
+
+      const upfrontPaymentPercent = (() => {
+        if (
+          data.upfrontPaymentPercent !== undefined &&
+          data.upfrontPaymentPercent !== null
+        ) {
+          const raw = Number(data.upfrontPaymentPercent);
+          return Number.isFinite(raw) ? Math.min(100, Math.max(0, raw)) : 0;
         }
-        if (nextStatus === "CANCELLED" && !hasPermission(perms, "sales", "reject")) {
-          throw new Error("NO_REJECT");
+        const existingPercent = Number((exists as any).upfrontPaymentPercent ?? 0);
+        return Number.isFinite(existingPercent) ? existingPercent : 0;
+      })();
+
+      let creditLimit: number | null = null;
+      let relationshipScore: number | null = null;
+      if (paymentCondition === "POSTPAID") {
+        const customer = await tx.customer.findUnique({
+          where: { id: data.customerId },
+          include: { dealerDetail: true },
+        });
+        if (!customer) {
+          throw new Error("CUSTOMER_NOT_FOUND");
         }
-        // Allow non-approvers to move between DRAFT and CONFIRMED (submit/recall)
-        const isFreeChange = (prevStatus === "DRAFT" && nextStatus === "CONFIRMED") || (prevStatus === "CONFIRMED" && nextStatus === "DRAFT");
-        if (!isFreeChange) {
-          const needsApprove = ["SHIPPED", "INVOICED", "APPROVED"].includes(nextStatus);
-          if (needsApprove && !hasPermission(perms, "sales", "approve")) {
-            throw new Error("NO_APPROVE");
-          }
+        creditLimit =
+          ((customer as any)?.dealerDetail?.creditLimit as number | undefined | null) ??
+          null;
+        relationshipScore = (customer as any)?.relationshipScore ?? null;
+      }
+
+      const evaluation = evaluateSaleOrderWorkflow({
+        paymentCondition,
+        grandTotal: totals.grandTotal,
+        upfrontPaymentPercent,
+        creditLimit,
+        relationshipScore,
+      });
+
+      let nextWorkflowStatus =
+        ((data as any).workflowStatus as any) ?? evaluation.workflowStatus;
+      let autoApprovedBySystem = Boolean(
+        (data as any).autoApprovedBySystem ?? evaluation.autoApprovedBySystem,
+      );
+      let creditEvaluationNote = evaluation.creditEvaluationNote;
+
+      const requestedStatus = String((data as any).status ?? exists.status ?? "DRAFT");
+      const wantsCancel =
+        requestedStatus === "CANCELLED" || nextWorkflowStatus === "CANCELLED";
+      const wantsApprove =
+        requestedStatus === "APPROVED" ||
+        nextWorkflowStatus === "APPROVED" ||
+        nextWorkflowStatus === "WAITING_PAYMENT_CONFIRMATION" ||
+        nextWorkflowStatus === "AUTO_APPROVED";
+
+      if (wantsCancel && !hasPermission(perms, "sales", "reject")) {
+        throw new Error("NO_REJECT");
+      }
+
+      if (
+        wantsApprove &&
+        !autoApprovedBySystem &&
+        !hasPermission(perms, "sales", "approve")
+      ) {
+        throw new Error("NO_APPROVE");
+      }
+
+      if (wantsCancel) {
+        nextWorkflowStatus = "CANCELLED";
+        autoApprovedBySystem = false;
+        creditEvaluationNote =
+          data.cancelReason || data.rejectReason || creditEvaluationNote || "ยกเลิกรายการ";
+      } else if (wantsApprove) {
+        if (nextWorkflowStatus === "AUTO_APPROVED" && !autoApprovedBySystem) {
+          autoApprovedBySystem = true;
+        }
+        if (nextWorkflowStatus !== "AUTO_APPROVED") {
+          nextWorkflowStatus =
+            paymentCondition === "PREPAID"
+              ? "WAITING_PAYMENT_CONFIRMATION"
+              : "APPROVED";
+          autoApprovedBySystem = false;
+        }
+        if (!creditEvaluationNote) {
+          creditEvaluationNote =
+            paymentCondition === "PREPAID"
+              ? "ผู้จัดการอนุมัติแล้ว รอตรวจสอบการชำระเงิน"
+              : "ผู้จัดการอนุมัติแล้ว";
+        }
+      } else if (!(data as any).workflowStatus) {
+        nextWorkflowStatus = evaluation.workflowStatus;
+        autoApprovedBySystem = evaluation.autoApprovedBySystem;
+      }
+
+      if (nextWorkflowStatus !== "AUTO_APPROVED") {
+        autoApprovedBySystem = false;
+      }
+
+      if (expiresAt && expiresAt.getTime() < Date.now() && !shippingDateValue) {
+        nextWorkflowStatus = "EXPIRED";
+        autoApprovedBySystem = false;
+        shippingLocked = true;
+      }
+
+      if (shippingDateChanged) {
+        shippingUpdateCount += 1;
+        if (shippingUpdateCount >= 3 && nextWorkflowStatus !== "SHIPPED") {
+          nextWorkflowStatus = "PENDING_SHIPMENT";
+          shippingLocked = true;
         }
       }
-      // If already approved and user wants to edit without reopening, block
-      if (prevStatus === "APPROVED" && nextStatus === "APPROVED") {
-        throw new Error("LOCKED_APPROVED");
+
+      if (
+        ["REJECTED", "EXPIRED", "CANCELLED"].includes(nextWorkflowStatus) &&
+        !hasPermission(perms, "sales", "reject")
+      ) {
+        throw new Error("NO_REJECT");
       }
+
+      const nextBaseStatus = mapWorkflowStatusToBaseStatus(nextWorkflowStatus as any);
+      const shouldApplyStock = shouldCommitStock(nextWorkflowStatus as any);
 
       // --- Promotion budget adjustment (difference-based and customer-change aware) ---
       const currentSpent = Number((exists as any).promotionSpent ?? 0);
-      const requestedSpent = (data as any).usePromotion ? Number((data as any).promotionAmount ?? 0) : 0;
+      const requestedSpent = (data as any).usePromotion
+        ? Number((data as any).promotionAmount ?? 0)
+        : 0;
       const oldCustomerId = (exists as any).customerId as string;
       const newCustomerId = data.customerId as string;
       if (oldCustomerId !== newCustomerId) {
-        // Refund full current to old customer (if any)
         if (currentSpent > 0) {
-          const oldCust = await (tx as any).customer.findUnique({ where: { id: oldCustomerId }, include: { dealerDetail: true } });
+          const oldCust = await (tx as any).customer.findUnique({
+            where: { id: oldCustomerId },
+            include: { dealerDetail: true },
+          });
           const oldDd = (oldCust as any)?.dealerDetail;
           if (oldDd?.id) {
-            await (tx as any).dealerDetail.update({ where: { id: oldDd.id }, data: { promotionBudget: { increment: currentSpent } } });
+            await (tx as any).dealerDetail.update({
+              where: { id: oldDd.id },
+              data: { promotionBudget: { increment: currentSpent } },
+            });
           } else {
-            // If cannot refund to old, block to avoid budget loss
-            throw new Error('PROMO_REFUND_TARGET_MISSING');
+            throw new Error("PROMO_REFUND_TARGET_MISSING");
           }
         }
-        // Deduct full requested from new customer (if any)
         if (requestedSpent > 0) {
-          const newCust = await (tx as any).customer.findUnique({ where: { id: newCustomerId }, include: { dealerDetail: true } });
+          const newCust = await (tx as any).customer.findUnique({
+            where: { id: newCustomerId },
+            include: { dealerDetail: true },
+          });
           const newDd = (newCust as any)?.dealerDetail;
           if (!newDd?.id) {
-            throw new Error('PROMO_NOT_SUPPORTED');
+            throw new Error("PROMO_NOT_SUPPORTED");
           }
           const result = await (tx as any).dealerDetail.updateMany({
             where: { id: newDd.id, promotionBudget: { gte: requestedSpent } },
             data: { promotionBudget: { decrement: requestedSpent } },
           });
           if (!result || (result.count ?? 0) !== 1) {
-            throw new Error('PROMO_BUDGET_NOT_ENOUGH');
+            throw new Error("PROMO_BUDGET_NOT_ENOUGH");
           }
         }
       } else {
-        // Same customer: apply delta change only
         const delta = requestedSpent - currentSpent;
         if (delta > 0) {
-          const cust = await (tx as any).customer.findUnique({ where: { id: newCustomerId }, include: { dealerDetail: true } });
+          const cust = await (tx as any).customer.findUnique({
+            where: { id: newCustomerId },
+            include: { dealerDetail: true },
+          });
           const dd = (cust as any)?.dealerDetail;
           if (!dd?.id) {
-            throw new Error('PROMO_NOT_SUPPORTED');
+            throw new Error("PROMO_NOT_SUPPORTED");
           }
           const result = await (tx as any).dealerDetail.updateMany({
             where: { id: dd.id, promotionBudget: { gte: delta } },
             data: { promotionBudget: { decrement: delta } },
           });
           if (!result || (result.count ?? 0) !== 1) {
-            throw new Error('PROMO_BUDGET_NOT_ENOUGH');
+            throw new Error("PROMO_BUDGET_NOT_ENOUGH");
           }
         } else if (delta < 0) {
           const refund = Math.abs(delta);
-          const cust = await (tx as any).customer.findUnique({ where: { id: newCustomerId }, include: { dealerDetail: true } });
+          const cust = await (tx as any).customer.findUnique({
+            where: { id: newCustomerId },
+            include: { dealerDetail: true },
+          });
           const dd = (cust as any)?.dealerDetail;
           if (!dd?.id) {
-            throw new Error('PROMO_REFUND_TARGET_MISSING');
+            throw new Error("PROMO_REFUND_TARGET_MISSING");
           }
-          await (tx as any).dealerDetail.update({ where: { id: dd.id }, data: { promotionBudget: { increment: refund } } });
+          await (tx as any).dealerDetail.update({
+            where: { id: dd.id },
+            data: { promotionBudget: { increment: refund } },
+          });
         }
       }
 
-      // release all existing reservations
-      await releaseReservations(tx, orderId);
-
-      // soft-delete existing items
+      await releaseOrderReservations(tx as any, orderId);
       await tx.saleOrderItem.deleteMany({ where: { saleOrderId: orderId } });
 
-      // If approving, ensure approver user exists to avoid FK violation
-      const actorId = nextStatus === "APPROVED" && session?.user?.id ? session.user.id : undefined;
-      const approver = actorId ? await tx.user.findUnique({ where: { id: actorId }, select: { id: true } }) : null;
+      const willBeApproved = nextBaseStatus === "APPROVED";
+      const wasApproved = prevBaseStatus === "APPROVED";
+      const actorId = willBeApproved && session?.user?.id ? session.user.id : undefined;
+      const approver = actorId
+        ? await tx.user.findUnique({ where: { id: actorId }, select: { id: true } })
+        : null;
+      const approvedAtValue = willBeApproved
+        ? (wasApproved && (exists as any).approvedAt
+            ? (exists as any).approvedAt
+            : new Date())
+        : null;
+      const approvedByUserId = willBeApproved
+        ? approver?.id ?? ((exists as any).approvedByUserId ?? null)
+        : null;
 
-      // update order header and recreate items
       const order = await (tx as any).saleOrder.update({
         where: { id: orderId },
         data: {
           customerId: data.customerId,
           salespersonId: data.salespersonId,
           orderDate: data.orderDate ? new Date(data.orderDate) : exists.orderDate,
-          dueDate: data.dueDate ? new Date(data.dueDate) : null,
-          shippingDate: data.shippingDate ? new Date(data.shippingDate) : null,
+          dueDate: dueDateValue ?? null,
+          shippingDate: shippingDateValue,
           creditTermDays: data.creditTermDays,
           currency: data.currency ?? "THB",
           vatIncluded: data.vatIncluded ?? true,
           vatRate: data.vatRate ?? 7,
           billTo: data.billTo,
           shipTo: data.shipTo,
-          status: (data.status as any) ?? exists.status,
+          status: nextBaseStatus as any,
+          workflowStatus: nextWorkflowStatus as any,
+          autoApprovedBySystem,
           paymentStatus: (data.paymentStatus as any) ?? exists.paymentStatus,
-          paymentCondition: (data.paymentCondition as any) ?? (exists as any).paymentCondition,
+          paymentCondition: paymentCondition as any,
           shippingFee: data.shippingFee ?? 0,
           otherCharges: data.otherCharges ?? 0,
           orderDiscount: (data as any).orderDiscount ?? 0,
           promotionSpent: requestedSpent || 0,
           poNumber: data.poNumber,
           note: data.note,
-          rejectReason: (data as any).rejectReason,
-          cancelReason: (data as any).cancelReason,
-          // Approval metadata update
-          approvedAt: nextStatus === "APPROVED" ? new Date() : (prevStatus === "APPROVED" && nextStatus !== "APPROVED" ? null : (exists as any).approvedAt),
-          approvedByUserId: nextStatus === "APPROVED" ? (approver?.id ?? null) : (prevStatus === "APPROVED" && nextStatus !== "APPROVED" ? null : (exists as any).approvedByUserId),
+          rejectReason: data.rejectReason,
+          cancelReason: data.cancelReason,
+          creditEvaluationNote,
+          upfrontPaymentPercent,
+          shippingUpdateCount,
+          shippingLocked,
+          expiresAt,
+          approvedAt: approvedAtValue,
+          approvedByUserId,
           subTotal: totals.subTotal,
           discountTotal: totals.discountTotal,
           taxAmount: totals.taxAmount,
@@ -353,39 +497,24 @@ export async function PUT(req: NextRequest, context: { params: Promise<{ orderId
                 expDate: it.expDate ? new Date(it.expDate) : null,
                 note: it.note,
               };
-            })
-          }
+            }),
+          },
         },
         include: { items: true },
       });
 
-      // Reserve or deduct stock per items depending on shippingDate or status
-      for (const item of (order.items as any[])) {
-        if (!item.productId || !item.qty) continue;
-        let remaining = Math.max(0, Math.floor(Number(item.qty)));
-        if (!Number.isFinite(remaining) || remaining <= 0) continue;
-        const stocks = await tx.stock.findMany({ where: { productId: item.productId, deletedAt: null }, orderBy: [{ expDate: "asc" }, { mfgDate: "asc" }, { createdAt: "asc" }] });
-        // Issue immediately if there is a shipping date OR order status is SHIPPED (COMPLETED in UI)
-        const isImmediateIssue = Boolean(order.shippingDate) || (order.status === "SHIPPED");
-        for (const s of stocks as any[]) {
-          if (remaining <= 0) break;
-          const onHand = Number(s.qtyOnHand || 0);
-          const reserved = Number(s.qtyReserved || 0);
-          const available = Math.max(0, onHand - reserved);
-          if (available <= 0) continue;
-          const alloc = Math.min(available, remaining);
-          if (alloc <= 0) continue;
-          if (isImmediateIssue) {
-            await tx.stock.update({ where: { id: s.id }, data: { qtyOnHand: { decrement: alloc } } });
-            await (tx as any).stockMovement.create({ data: { stockId: s.id, productId: s.productId, saleOrderId: order.id, type: 'ISSUE', qty: alloc } });
-          } else {
-            await tx.stock.update({ where: { id: s.id }, data: { qtyReserved: { increment: alloc } } });
-            await (tx as any).saleOrderStockReservation.create({ data: { saleOrderId: order.id, stockId: s.id, qty: alloc } });
-            await (tx as any).stockMovement.create({ data: { stockId: s.id, productId: s.productId, saleOrderId: order.id, type: 'RESERVE', qty: alloc } });
-          }
-          remaining -= alloc;
-        }
+      if (shouldApplyStock) {
+        await rebuildOrderStockCommit(tx as any, {
+          id: order.id,
+          shippingDate: order.shippingDate,
+          items: order.items.map((it: any) => ({
+            id: it.id,
+            productId: it.productId ?? null,
+            qty: it.qty ?? 0,
+          })),
+        });
       }
+
       return order;
     });
 
@@ -395,10 +524,7 @@ export async function PUT(req: NextRequest, context: { params: Promise<{ orderId
       return NextResponse.json({ error: "ไม่พบใบสั่งขาย" }, { status: 404 });
     }
     if (err instanceof Error && err.message === "LOCKED") {
-      return NextResponse.json({ error: "เอกสารสถานะสำเร็จ ไม่สามารถแก้ไขได้" }, { status: 400 });
-    }
-    if (err instanceof Error && err.message === "LOCKED_APPROVED") {
-      return NextResponse.json({ error: "เอกสารถูกอนุมัติแล้ว ต้องเปลี่ยนสถานะเป็นรออนุมัติจึงจะแก้ไขได้" }, { status: 400 });
+      return NextResponse.json({ error: "เอกสารสถานะนี้ไม่สามารถแก้ไขได้" }, { status: 400 });
     }
     if (err instanceof Error && err.message === "NO_APPROVE") {
       return NextResponse.json({ error: "ไม่มีสิทธิ์เปลี่ยนแปลงสถานะ/อนุมัติเอกสาร" }, { status: 403 });
@@ -406,13 +532,19 @@ export async function PUT(req: NextRequest, context: { params: Promise<{ orderId
     if (err instanceof Error && err.message === "NO_REJECT") {
       return NextResponse.json({ error: "ไม่มีสิทธิ์ปฏิเสธ/ยกเลิกเอกสาร" }, { status: 403 });
     }
-    if (err instanceof Error && err.message === 'PROMO_NOT_SUPPORTED') {
+    if (err instanceof Error && err.message === "CUSTOMER_NOT_FOUND") {
+      return NextResponse.json({ error: "ไม่พบข้อมูลลูกค้า" }, { status: 400 });
+    }
+    if (err instanceof Error && err.message === "SHIPPING_LOCKED") {
+      return NextResponse.json({ error: "อัปเดตวันส่งของเกินจำนวนครั้งที่กำหนดแล้ว" }, { status: 400 });
+    }
+    if (err instanceof Error && err.message === "PROMO_NOT_SUPPORTED") {
       return NextResponse.json({ error: "ลูกค้ารายนี้ไม่รองรับวงเงินส่งเสริมการขาย" }, { status: 400 });
     }
-    if (err instanceof Error && err.message === 'PROMO_BUDGET_NOT_ENOUGH') {
+    if (err instanceof Error && err.message === "PROMO_BUDGET_NOT_ENOUGH") {
       return NextResponse.json({ error: "วงเงินส่งเสริมการขายคงเหลือไม่พอ" }, { status: 400 });
     }
-    if (err instanceof Error && err.message === 'PROMO_REFUND_TARGET_MISSING') {
+    if (err instanceof Error && err.message === "PROMO_REFUND_TARGET_MISSING") {
       return NextResponse.json({ error: "ไม่สามารถคืนวงเงินส่งเสริมการขายเดิมได้" }, { status: 400 });
     }
     console.error("[PUT /api/sales/orders/:id] error", err);

--- a/app/api/sales/orders/route.ts
+++ b/app/api/sales/orders/route.ts
@@ -5,6 +5,12 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { hasPermission } from "@/lib/permissions";
 import { buildSaleOrderVisibilityWhere, getVisibilityScope } from "@/lib/sales-visibility";
+import {
+  evaluateSaleOrderWorkflow,
+  mapWorkflowStatusToBaseStatus,
+  shouldCommitStock,
+} from "@/lib/sales-approval";
+import { rebuildOrderStockCommit } from "@/lib/sale-order-stock";
 
 export const runtime = "nodejs";
 
@@ -32,6 +38,7 @@ const CreateOrderSchema = z.object({
   shippingDate: z.string().datetime().optional(),
   creditTermDays: z.number().int().optional(),
   paymentCondition: z.enum(["PREPAID","POSTPAID"]).optional(),
+  upfrontPaymentPercent: z.number().min(0).max(100).optional().default(0),
   currency: z.string().default("THB"),
   vatIncluded: z.boolean().default(true),
   vatRate: z.number().min(0).default(7),
@@ -176,40 +183,28 @@ export async function GET(req: NextRequest) {
 
     // Apply workflow mapping to where when provided
     if (workflow && workflow !== "ALL") {
-      switch (workflow) {
-        case "DRAFT":
-          where.status = "DRAFT";
-          break;
-        case "PENDING_APPROVAL":
-        case "AWAITING_STOCK":
-          where.status = "CONFIRMED";
-          break;
-        case "APPROVED":
-        case "READY_TO_SHIP":
-          where.status = "APPROVED";
-          break;
-        case "REJECTED":
-        case "CANCELLED":
-          where.status = "CANCELLED";
-          break;
-        case "AWAITING_PAYMENT":
-          where.status = "INVOICED";
-          where.paymentStatus = { in: ["UNPAID", "PARTIAL", "OVERDUE"] };
-          break;
-        case "PAID":
-          where.status = "INVOICED";
-          where.paymentStatus = "PAID";
-          break;
-        case "IN_TRANSIT":
-          where.status = "SHIPPED";
-          where.paymentStatus = { in: ["UNPAID", "PARTIAL", "OVERDUE"] };
-          break;
-        case "COMPLETED":
-          where.status = "SHIPPED";
-          where.paymentStatus = "PAID";
-          break;
-        default:
-          break;
+      const wfMap: Record<string, string | string[]> = {
+        DRAFT: "DRAFT",
+        PENDING_APPROVAL: "WAITING_MANAGER_APPROVAL",
+        WAITING_MANAGER_APPROVAL: "WAITING_MANAGER_APPROVAL",
+        WAITING_PAYMENT_CONFIRMATION: "WAITING_PAYMENT_CONFIRMATION",
+        WAITING_CREDIT_EXTENSION: "WAITING_CREDIT_EXTENSION",
+        AUTO_APPROVED: ["AUTO_APPROVED", "APPROVED"],
+        APPROVED: ["APPROVED", "AUTO_APPROVED"],
+        REJECTED: "REJECTED",
+        CANCELLED: "CANCELLED",
+        EXPIRED: "EXPIRED",
+        PENDING_SHIPMENT: "PENDING_SHIPMENT",
+        READY_TO_SHIP: "PENDING_SHIPMENT",
+        SHIPPED: "SHIPPED",
+        IN_TRANSIT: "SHIPPED",
+        COMPLETED: "SHIPPED",
+      };
+      const wfTarget = wfMap[workflow] ?? workflow;
+      if (Array.isArray(wfTarget)) {
+        where.workflowStatus = { in: wfTarget } as any;
+      } else {
+        where.workflowStatus = wfTarget as any;
       }
     }
 
@@ -278,8 +273,14 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "ไม่มีสิทธิ์ปฏิเสธ/ยกเลิกเอกสาร" }, { status: 403 });
     }
 
-    // Pre-check credit if POSTPAID
-    if ((data.paymentCondition ?? "PREPAID") === "POSTPAID") {
+    const paymentCondition = (data.paymentCondition as any) ?? "PREPAID";
+    const upfrontRaw = Number(data.upfrontPaymentPercent ?? 0);
+    const upfrontPaymentPercent = Number.isFinite(upfrontRaw)
+      ? Math.min(100, Math.max(0, upfrontRaw))
+      : 0;
+    let creditLimit: number | null = null;
+    let relationshipScore: number | null = null;
+    if (paymentCondition === "POSTPAID") {
       const customer = await prisma.customer.findUnique({
         where: { id: data.customerId },
         include: { dealerDetail: true },
@@ -287,18 +288,44 @@ export async function POST(req: NextRequest) {
       if (!customer) {
         return NextResponse.json({ error: "ไม่พบลูกค้า" }, { status: 400 });
       }
-      const creditLimit = (customer as any)?.dealerDetail?.creditLimit as number | null | undefined;
-      if (typeof creditLimit === 'number') {
-        const relationshipScore = (customer as any)?.relationshipScore as number | null | undefined;
-        const enoughCredit = totals.grandTotal <= creditLimit;
-        if (!enoughCredit) {
-          const canOverride = typeof relationshipScore === 'number' && relationshipScore > 3;
-          if (!canOverride) {
-            return NextResponse.json({ error: "วงเงินเครดิตไม่พอ และคะแนนความสัมพันธ์ไม่ถึงเกณฑ์" }, { status: 400 });
-          }
-        }
-      }
+      creditLimit = ((customer as any)?.dealerDetail?.creditLimit as number | undefined | null) ?? null;
+      relationshipScore = (customer as any)?.relationshipScore ?? null;
     }
+
+    const evaluation = evaluateSaleOrderWorkflow({
+      paymentCondition,
+      grandTotal: totals.grandTotal,
+      upfrontPaymentPercent,
+      creditLimit,
+      relationshipScore,
+    });
+
+    let workflowStatus = evaluation.workflowStatus;
+    let baseStatus = evaluation.baseStatus;
+    let autoApprovedBySystem = evaluation.autoApprovedBySystem;
+    let creditEvaluationNote = evaluation.creditEvaluationNote;
+
+    if (wantsCancel) {
+      workflowStatus = "CANCELLED";
+      baseStatus = "CANCELLED";
+      autoApprovedBySystem = false;
+      creditEvaluationNote = "ยกเลิกรายการตามคำสั่งผู้ใช้";
+    } else if (wantsApprove) {
+      workflowStatus =
+        paymentCondition === "PREPAID"
+          ? "WAITING_PAYMENT_CONFIRMATION"
+          : "APPROVED";
+      baseStatus = mapWorkflowStatusToBaseStatus(workflowStatus);
+      autoApprovedBySystem = false;
+      creditEvaluationNote =
+        paymentCondition === "PREPAID"
+          ? "ผู้จัดการอนุมัติแล้ว รอตรวจสอบการชำระเงิน"
+          : "ผู้จัดการอนุมัติแล้ว";
+    }
+
+    const shouldApplyStock = shouldCommitStock(workflowStatus);
+    const expiresAt = data.dueDate ? new Date(data.dueDate) : null;
+    const shippingDateValue = data.shippingDate ? new Date(data.shippingDate) : null;
 
     let created: any | null = null;
     for (let attempt = 0; attempt < 5; attempt++) {
@@ -347,32 +374,45 @@ export async function POST(req: NextRequest) {
           const actorId = wantsApprove && session?.user?.id ? session.user.id : undefined;
           const approver = actorId ? await tx.user.findUnique({ where: { id: actorId }, select: { id: true } }) : null;
 
+          const approvedAtValue =
+            baseStatus === "APPROVED" && (autoApprovedBySystem || wantsApprove)
+              ? new Date()
+              : null;
+          const approvedById = wantsApprove && approver?.id ? approver.id : null;
+
           const order = await (tx as any).saleOrder.create({
             data: {
               soNumber,
               customerId: data.customerId,
               salespersonId,
               orderDate: data.orderDate ? new Date(data.orderDate) : new Date(),
-              dueDate: data.dueDate ? new Date(data.dueDate) : null,
-              shippingDate: data.shippingDate ? new Date(data.shippingDate) : null,
+              dueDate: expiresAt,
+              shippingDate: shippingDateValue,
               creditTermDays: data.creditTermDays,
-          currency: data.currency ?? "THB",
-          vatIncluded: data.vatIncluded ?? true,
-          vatRate: data.vatRate ?? 7,
-          billTo: data.billTo,
-          shipTo: data.shipTo,
-          status: (data.status as any) ?? "DRAFT",
-          paymentStatus: (data.paymentStatus as any) ?? "UNPAID",
-          paymentCondition: (data.paymentCondition as any) ?? "PREPAID",
-          shippingFee: data.shippingFee ?? 0,
-          otherCharges: data.otherCharges ?? 0,
-          orderDiscount: data.orderDiscount ?? 0,
-          promotionSpent: promoUsed || 0,
-          poNumber: data.poNumber,
-          note: data.note,
-          rejectReason: (data as any).rejectReason,
-          approvedAt: wantsApprove ? new Date() : null,
-          approvedByUserId: wantsApprove ? (approver?.id ?? null) : null,
+              currency: data.currency ?? "THB",
+              vatIncluded: data.vatIncluded ?? true,
+              vatRate: data.vatRate ?? 7,
+              billTo: data.billTo,
+              shipTo: data.shipTo,
+              status: baseStatus as any,
+              workflowStatus: workflowStatus as any,
+              autoApprovedBySystem,
+              paymentStatus: (data.paymentStatus as any) ?? "UNPAID",
+              paymentCondition: paymentCondition as any,
+              shippingFee: data.shippingFee ?? 0,
+              otherCharges: data.otherCharges ?? 0,
+              orderDiscount: data.orderDiscount ?? 0,
+              promotionSpent: promoUsed || 0,
+              poNumber: data.poNumber,
+              note: data.note,
+              rejectReason: (data as any).rejectReason,
+              creditEvaluationNote,
+              upfrontPaymentPercent,
+              shippingUpdateCount: 0,
+              shippingLocked: false,
+              expiresAt,
+              approvedAt: approvedAtValue,
+              approvedByUserId: approvedById,
               subTotal: totals.subTotal,
               discountTotal: totals.discountTotal,
               taxAmount: totals.taxAmount,
@@ -390,7 +430,7 @@ export async function POST(req: NextRequest) {
                     discountPercent: it.discountPercent ?? 0,
                     discountAmount: it.discountAmount ?? 0,
                     lineVatRate: it.lineVatRate ?? undefined,
-                    amount: taxable, // amount before VAT per line
+                    amount: taxable,
                     lotNumber: it.lotNumber,
                     mfgDate: it.mfgDate ? new Date(it.mfgDate) : null,
                     expDate: it.expDate ? new Date(it.expDate) : null,
@@ -402,40 +442,18 @@ export async function POST(req: NextRequest) {
             include: { items: true },
           });
 
-          // Reserve or Deduct stock per item depending on shippingDate or status
-          for (const item of order.items as any[]) {
-            if (!item.productId || !item.qty) continue;
-            let remaining = Math.max(0, Math.floor(Number(item.qty)));
-            if (!Number.isFinite(remaining) || remaining <= 0) continue;
-
-            const stocks = await tx.stock.findMany({
-              where: { productId: item.productId, deletedAt: null },
-              orderBy: [{ expDate: "asc" }, { mfgDate: "asc" }, { createdAt: "asc" }],
+          if (shouldApplyStock) {
+            await rebuildOrderStockCommit(tx as any, {
+              id: order.id,
+              shippingDate: order.shippingDate,
+              items: order.items.map((it: any) => ({
+                id: it.id,
+                productId: it.productId ?? null,
+                qty: it.qty ?? 0,
+              })),
             });
-
-            // Issue immediately if there is a shipping date OR order status is SHIPPED (COMPLETED in UI)
-            const isImmediateIssue = Boolean(order.shippingDate) || (order.status === "SHIPPED");
-            for (const s of stocks as any[]) {
-              if (remaining <= 0) break;
-              const onHand = Number(s.qtyOnHand || 0);
-              const reserved = Number(s.qtyReserved || 0);
-              const available = Math.max(0, onHand - reserved);
-              if (available <= 0) continue;
-              const alloc = Math.min(available, remaining);
-              if (alloc <= 0) continue;
-              if (isImmediateIssue) {
-                // Deduct on-hand immediately, do not reserve
-                await tx.stock.update({ where: { id: s.id }, data: { qtyOnHand: { decrement: alloc } } });
-                await (tx as any).stockMovement.create({ data: { stockId: s.id, productId: s.productId, saleOrderId: order.id, type: 'ISSUE', qty: alloc } });
-              } else {
-                // Reserve only
-                await tx.stock.update({ where: { id: s.id }, data: { qtyReserved: { increment: alloc } } });
-                await (tx as any).saleOrderStockReservation.create({ data: { saleOrderId: order.id, stockId: s.id, qty: alloc } });
-                await (tx as any).stockMovement.create({ data: { stockId: s.id, productId: s.productId, saleOrderId: order.id, type: 'RESERVE', qty: alloc } });
-              }
-              remaining -= alloc;
-            }
           }
+
           return order;
         });
         break; // success

--- a/app/dashboard/sales/orders/[orderId]/edit/_components/edit-order-page-client.tsx
+++ b/app/dashboard/sales/orders/[orderId]/edit/_components/edit-order-page-client.tsx
@@ -57,6 +57,7 @@ export function EditOrderPageClient({ orderId, customerOptions, employeeOptions,
           shipPostalCode: (so as any)?.customer?.postalCode ?? undefined,
           status: String(so.status || "DRAFT"),
           paymentStatus: String(so.paymentStatus || "UNPAID"),
+          workflowStatus: String((so as any).workflowStatus || "DRAFT"),
           shippingFee: Number(so.shippingFee ?? 0),
           otherCharges: Number(so.otherCharges ?? 0),
           orderDiscount: Number((so as any).orderDiscount ?? 0),
@@ -67,6 +68,14 @@ export function EditOrderPageClient({ orderId, customerOptions, employeeOptions,
           items,
           rejectReason: (so as any).rejectReason || "",
           cancelReason: (so as any).cancelReason || "",
+          upfrontPaymentPercent:
+            typeof (so as any).upfrontPaymentPercent === "number"
+              ? Number((so as any).upfrontPaymentPercent)
+              : "",
+          autoApprovedBySystem: Boolean((so as any).autoApprovedBySystem),
+          shippingUpdateCount: Number((so as any).shippingUpdateCount ?? 0),
+          shippingLocked: Boolean((so as any).shippingLocked ?? false),
+          creditEvaluationNote: (so as any).creditEvaluationNote || "",
         });
       } catch (e: any) {
         setError(e?.message || "โหลดข้อมูลไม่สำเร็จ");

--- a/app/dashboard/sales/orders/_components/order-form.tsx
+++ b/app/dashboard/sales/orders/_components/order-form.tsx
@@ -48,15 +48,17 @@ const DEFAULT_ITEM: OrderItemInput = {
   discountAmount: "",
 };
 
-const STATUS_OPTIONS = [
+const WORKFLOW_STATUS_OPTIONS = [
   { value: "DRAFT", label: "ร่าง" },
-  { value: "PENDING_APPROVAL", label: "รออนุมัติ" },
+  { value: "WAITING_MANAGER_APPROVAL", label: "รออนุมัติผู้จัดการ" },
+  { value: "WAITING_PAYMENT_CONFIRMATION", label: "รอตรวจสอบการชำระเงิน" },
+  { value: "WAITING_CREDIT_EXTENSION", label: "รอเพิ่มวงเงินเครดิต" },
+  { value: "AUTO_APPROVED", label: "ระบบอนุมัติอัตโนมัติ" },
   { value: "APPROVED", label: "อนุมัติ" },
+  { value: "PENDING_SHIPMENT", label: "รอจัดส่ง" },
+  { value: "SHIPPED", label: "จัดส่งแล้ว" },
   { value: "REJECTED", label: "ปฏิเสธ" },
-  { value: "AWAITING_STOCK", label: "รอสินค้า" },
-  { value: "READY_TO_SHIP", label: "รอจัดส่ง" },
-  { value: "IN_TRANSIT", label: "อยู่ระหว่างจัดส่ง" },
-  { value: "COMPLETED", label: "สำเร็จ" },
+  { value: "EXPIRED", label: "หมดอายุ" },
   { value: "CANCELLED", label: "ยกเลิก" },
 ];
 
@@ -151,7 +153,9 @@ export function OrderForm({
   const [shipPostalCode, setShipPostalCode] = useState<string | undefined>(initial?.shipPostalCode);
   const [status, setStatus] = useState(initial?.status ?? "DRAFT");
   const [paymentStatus, setPaymentStatus] = useState(initial?.paymentStatus ?? "UNPAID");
-  const [workflowStatus, setWorkflowStatus] = useState<string>(initial?.status ?? "DRAFT");
+  const [workflowStatus, setWorkflowStatus] = useState<string>(
+    initial?.workflowStatus ?? initial?.status ?? "DRAFT",
+  );
   const [shippingFee, setShippingFee] = useState<number | "">(initial?.shippingFee ?? 0);
   const [otherCharges, setOtherCharges] = useState<number | "">(initial?.otherCharges ?? 0);
   const [poNumber, setPoNumber] = useState(initial?.poNumber ?? "");
@@ -181,6 +185,14 @@ export function OrderForm({
   const [otherChargesInput, setOtherChargesInput] = useState<string | null>(null);
   const [orderDiscountInput, setOrderDiscountInput] = useState<string | null>(null);
   const [itemDiscountInput, setItemDiscountInput] = useState<Record<number, string | undefined>>({});
+  const [upfrontPercentInput, setUpfrontPercentInput] = useState<string | null>(null);
+  const [upfrontPaymentPercent, setUpfrontPaymentPercent] = useState<number | "">(
+    initial?.upfrontPaymentPercent ?? "",
+  );
+
+  const shippingLocked = Boolean(initial?.shippingLocked ?? false);
+  const shippingUpdateCount = Number(initial?.shippingUpdateCount ?? 0);
+  const creditEvaluationNote = initial?.creditEvaluationNote ?? "";
 
   const totals = useMemo(
     () =>
@@ -198,7 +210,7 @@ export function OrderForm({
     return net;
   }, [totals, orderDiscount]);
 
-  const allowedStatusOptions = STATUS_OPTIONS;
+  const allowedStatusOptions = WORKFLOW_STATUS_OPTIONS;
 
   const needRejectReason = mode === "edit" && workflowStatus === "REJECTED";
   const needCancelReason = mode === "edit" && workflowStatus === "CANCELLED";
@@ -303,41 +315,45 @@ export function OrderForm({
   }, [creditTermDays, orderDate, paymentCondition]);
 
   const applyWorkflowMapping = (wf: string) => {
-    setWorkflowStatus(wf);
+    setWorkflowStatus((prev) => (prev === wf ? prev : wf));
     switch (wf) {
       case "DRAFT":
         setStatus("DRAFT");
         setPaymentStatus("UNPAID");
         break;
-      case "PENDING_APPROVAL":
+      case "WAITING_MANAGER_APPROVAL":
         setStatus("CONFIRMED");
         break;
-      case "APPROVED":
+      case "WAITING_PAYMENT_CONFIRMATION":
         setStatus("APPROVED");
+        break;
+      case "WAITING_CREDIT_EXTENSION":
+        setStatus("CONFIRMED");
+        break;
+      case "AUTO_APPROVED":
+      case "APPROVED":
+      case "PENDING_SHIPMENT":
+        setStatus("APPROVED");
+        break;
+      case "SHIPPED":
+        setStatus("SHIPPED");
         break;
       case "REJECTED":
+      case "CANCELLED":
         setStatus("CANCELLED");
         break;
-      case "AWAITING_STOCK":
-        setStatus("CONFIRMED");
-        break;
-      case "READY_TO_SHIP":
-        setStatus("APPROVED");
-        break;
-      case "IN_TRANSIT":
-        setStatus("SHIPPED");
-        break;
-      case "COMPLETED":
-        setStatus("SHIPPED");
-        setPaymentStatus("PAID");
-        break;
-      case "CANCELLED":
+      case "EXPIRED":
         setStatus("CANCELLED");
         break;
       default:
         break;
     }
   };
+
+  useEffect(() => {
+    applyWorkflowMapping(workflowStatus);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const canSubmit =
     customerId &&
@@ -378,7 +394,7 @@ export function OrderForm({
         return parts.join(" ");
       };
 
-      const statusForSubmit = mode === "create" ? "CONFIRMED" : status;
+      const statusForSubmit = status;
       const payload: any = {
         customerId,
         salespersonId: salespersonId || undefined,
@@ -408,6 +424,7 @@ export function OrderForm({
           ) || undefined,
         status: statusForSubmit,
         paymentStatus,
+        workflowStatus: mode === "edit" ? workflowStatus : undefined,
         shippingFee: Number(shippingFee || 0),
         otherCharges: Number(otherCharges || 0),
         orderDiscount: orderDiscount === "" ? 0 : Number(orderDiscount || 0),
@@ -428,6 +445,9 @@ export function OrderForm({
           discountAmount: Number(it.discountAmount || 0),
         })),
       };
+
+      payload.upfrontPaymentPercent =
+        upfrontPaymentPercent === "" ? 0 : Number(upfrontPaymentPercent);
 
       await onSubmit(payload);
     } catch (err: any) {
@@ -620,6 +640,10 @@ export function OrderForm({
               if (val === "PREPAID") {
                 setCreditTermDays("");
                 setDueDate(null);
+                setUpfrontPaymentPercent("");
+              }
+              if (val === "POSTPAID" && upfrontPaymentPercent === "") {
+                setUpfrontPaymentPercent(0);
               }
             }}
             fullWidth
@@ -666,6 +690,49 @@ export function OrderForm({
               </MenuItem>
             ))}
           </TextField>
+          <TextField
+            label="เปอร์เซ็นต์ชำระล่วงหน้า (%)"
+            value={
+              upfrontPercentInput !== null
+                ? upfrontPercentInput
+                : upfrontPaymentPercent === ""
+                ? ""
+                : String(upfrontPaymentPercent)
+            }
+            onChange={(e) => {
+              const raw = e.target.value;
+              setUpfrontPercentInput(raw);
+              if (raw.trim() === "") {
+                setUpfrontPaymentPercent("");
+                return;
+              }
+              const sanitized = raw.replace(/[^0-9.]/g, "");
+              if (!sanitized) {
+                setUpfrontPaymentPercent("");
+                return;
+              }
+              const [intPart, fracPart] = sanitized.split(".");
+              const normalized =
+                intPart.slice(0, 3) + (fracPart !== undefined ? `.${fracPart.slice(0, 2)}` : "");
+              const numeric = Number(normalized);
+              if (!Number.isNaN(numeric)) {
+                setUpfrontPaymentPercent(Math.min(100, Math.max(0, numeric)));
+              }
+            }}
+            onBlur={() => {
+              setUpfrontPercentInput(null);
+              if (upfrontPaymentPercent === "") return;
+              const numeric = Number(upfrontPaymentPercent);
+              if (Number.isNaN(numeric)) {
+                setUpfrontPaymentPercent(0);
+              } else if (numeric > 100) {
+                setUpfrontPaymentPercent(100);
+              }
+            }}
+            disabled={paymentCondition !== "POSTPAID"}
+            helperText="ใช้สำหรับประเมินการอนุมัติอัตโนมัติ"
+            fullWidth
+          />
         </Stack>
       </Box>
 
@@ -805,7 +872,7 @@ export function OrderForm({
           <TextField
             select
             label="สถานะ"
-            value={mode === "create" ? "PENDING_APPROVAL" : (workflowStatus as any)}
+            value={workflowStatus as any}
             onChange={(e) => applyWorkflowMapping(e.target.value)}
             fullWidth
             disabled
@@ -818,6 +885,17 @@ export function OrderForm({
           </TextField>
         </Stack>
       </Box>
+
+      {creditEvaluationNote && (
+        <Alert severity="info" sx={{ mt: 1 }}>
+          {creditEvaluationNote}
+        </Alert>
+      )}
+      {shippingLocked && (
+        <Alert severity="warning" sx={{ mt: 1 }}>
+          {`ปิดการแก้ไขวันที่จัดส่ง (อัปเดตแล้ว ${shippingUpdateCount} ครั้ง)`}
+        </Alert>
+      )}
 
       {needRejectReason && (
         <TextField

--- a/app/dashboard/sales/orders/_components/orders-client.tsx
+++ b/app/dashboard/sales/orders/_components/orders-client.tsx
@@ -66,8 +66,10 @@ type OrderItem = {
   shippingDate?: string | null;
   grandTotal: number;
   status: string;
+  workflowStatus?: string | null;
   paymentCondition?: string;
   paymentStatus: string;
+  autoApprovedBySystem?: boolean;
   customer?: {
     id: string;
     name?: string;
@@ -113,24 +115,45 @@ const visuallyHidden = {
 const WORKFLOW_STATUS_OPTIONS = [
   { value: "ALL", label: "ทั้งหมด" },
   { value: "DRAFT", label: "ร่าง" },
-  { value: "PENDING_APPROVAL", label: "รออนุมัติ" },
+  { value: "WAITING_MANAGER_APPROVAL", label: "รออนุมัติผู้จัดการ" },
+  { value: "WAITING_PAYMENT_CONFIRMATION", label: "รอตรวจสอบการชำระเงิน" },
+  { value: "WAITING_CREDIT_EXTENSION", label: "รอเพิ่มวงเงินเครดิต" },
+  { value: "AUTO_APPROVED", label: "ระบบอนุมัติอัตโนมัติ" },
   { value: "APPROVED", label: "อนุมัติ" },
+  { value: "PENDING_SHIPMENT", label: "รอจัดส่ง" },
+  { value: "SHIPPED", label: "จัดส่งแล้ว" },
   { value: "REJECTED", label: "ปฏิเสธ" },
-  { value: "AWAITING_STOCK", label: "รอสินค้า" },
-  { value: "READY_TO_SHIP", label: "รอจัดส่ง" },
-  { value: "IN_TRANSIT", label: "อยู่ระหว่างจัดส่ง" },
-  { value: "COMPLETED", label: "สำเร็จ" },
+  { value: "EXPIRED", label: "หมดอายุ" },
   { value: "CANCELLED", label: "ยกเลิก" },
 ];
 
-function workflowFromBackend(status: string, paymentStatus: string): string {
-  if (status === "DRAFT") return "DRAFT";
-  if (status === "CANCELLED") return "CANCELLED"; // could also represent REJECTED
-  if (status === "INVOICED") return "READY_TO_SHIP"; // move payment-related labels to payment status
-  if (status === "SHIPPED") return paymentStatus === "PAID" ? "COMPLETED" : "IN_TRANSIT";
-  if (status === "APPROVED") return "APPROVED"; // or READY_TO_SHIP
-  if (status === "CONFIRMED") return "PENDING_APPROVAL"; // or AWAITING_STOCK
-  return status || "DRAFT";
+const WORKFLOW_STATUS_SET = new Set(WORKFLOW_STATUS_OPTIONS.filter((o) => o.value !== "ALL").map((o) => o.value));
+const TERMINAL_WORKFLOW_SET = new Set(["CANCELLED", "REJECTED", "EXPIRED", "SHIPPED"]);
+
+function workflowFromBackend(status: string, paymentStatus: string, workflowStatus?: string | null): string {
+  const normalized = (workflowStatus || "").toUpperCase();
+  if (normalized && WORKFLOW_STATUS_SET.has(normalized)) {
+    return normalized;
+  }
+
+  switch ((status || "").toUpperCase()) {
+    case "DRAFT":
+      return "DRAFT";
+    case "CONFIRMED":
+      return "WAITING_MANAGER_APPROVAL";
+    case "APPROVED":
+      return "APPROVED";
+    case "INVOICED":
+      return "PENDING_SHIPMENT";
+    case "SHIPPED":
+      return "SHIPPED";
+    case "CANCELLED":
+      return "CANCELLED";
+    default:
+      // fall back to payment-derived hints for legacy rows
+      if (paymentStatus === "PAID") return "WAITING_PAYMENT_CONFIRMATION";
+      return "DRAFT";
+  }
 }
 
 // Server now supports workflow filter directly via `workflow` query param
@@ -368,11 +391,13 @@ export function OrdersClient({ customerOptions, employeeOptions, productOptions 
   };
 
   function workflowChipSx(wf: string) {
-    if (wf === "COMPLETED") return { color: "common.white", bgcolor: "success.main" } as const;
-    if (wf === "CANCELLED" || wf === "REJECTED")
-      return { color: "common.white", bgcolor: "error.main" } as const;
-    if (wf === "IN_TRANSIT" || wf === "READY_TO_SHIP" || wf === "AWAITING_STOCK")
+    if (wf === "SHIPPED") return { color: "common.white", bgcolor: "success.dark" } as const;
+    if (["APPROVED", "AUTO_APPROVED", "WAITING_PAYMENT_CONFIRMATION"].includes(wf))
+      return { color: "common.white", bgcolor: "success.main" } as const;
+    if (["WAITING_MANAGER_APPROVAL", "WAITING_CREDIT_EXTENSION", "PENDING_SHIPMENT"].includes(wf))
       return { color: "grey.900", bgcolor: "warning.light" } as const;
+    if (["REJECTED", "CANCELLED", "EXPIRED"].includes(wf))
+      return { color: "common.white", bgcolor: "error.main" } as const;
     return { color: "text.primary", bgcolor: "grey.200" } as const;
   }
 
@@ -628,20 +653,30 @@ export function OrdersClient({ customerOptions, employeeOptions, productOptions 
       {/* Mobile cards layout */}
       <Stack spacing={1.25} sx={{ p: 1.5, display: { xs: "block", md: "none" } }}>
         {sortedItems.map((o) => {
-          const rawWf = workflowFromBackend(o.status, o.paymentStatus);
-          const wf = o.status === "CANCELLED" && (o as any)?.rejectReason ? "REJECTED" : rawWf;
-          const isTerminal = wf === "COMPLETED" || wf === "CANCELLED";
+          const wf = workflowFromBackend(o.status, o.paymentStatus, o.workflowStatus);
+          const isTerminal = TERMINAL_WORKFLOW_SET.has(wf);
           const wfLabel = WORKFLOW_STATUS_OPTIONS.find((x) => x.value === wf)?.label || o.status;
+          const autoApproved = Boolean(o.autoApprovedBySystem);
           return (
             <Paper key={o.id} variant="outlined" sx={{ p: 1.25, borderRadius: 2 }}>
               <Stack spacing={1}>
                 <Stack direction="row" justifyContent="space-between" alignItems="center">
                   <Typography fontWeight={700}>SO {o.soNumber}</Typography>
-                  <Chip
-                    size="small"
-                    label={wfLabel}
-                    sx={{ fontWeight: 600, px: 1.2, borderRadius: "9999px", ...workflowChipSx(wf) }}
-                  />
+                  <Stack direction="row" spacing={0.5} alignItems="center">
+                    <Chip
+                      size="small"
+                      label={wfLabel}
+                      sx={{ fontWeight: 600, px: 1.2, borderRadius: "9999px", ...workflowChipSx(wf) }}
+                    />
+                    {autoApproved && (
+                      <Chip
+                        size="small"
+                        color="secondary"
+                        label="อนุมัติอัตโนมัติ"
+                        sx={{ fontWeight: 600, borderRadius: "9999px" }}
+                      />
+                    )}
+                  </Stack>
                 </Stack>
                 <Typography variant="body2" color="text.secondary">
                   ลูกค้า: {displayCustomerName(o.customer)}
@@ -677,15 +712,11 @@ export function OrdersClient({ customerOptions, employeeOptions, productOptions 
                     )}
                     \n{" "}
                     {!isTerminal && canEdit && (
-                      <Tooltip
-                        title={wf === "COMPLETED" ? "แก้ไขไม่ได้ (เสร็จสิ้น)" : "แก้ไข"}
-                        arrow
-                      >
+                      <Tooltip title="แก้ไข" arrow>
                         <span>
                           <IconButton
                             size="small"
                             color="secondary"
-                            disabled={wf === "COMPLETED"}
                             onClick={() => router.push(`/dashboard/sales/orders/${o.id}/edit`)}
                           >
                             <EditOutlinedIcon fontSize="small" />
@@ -754,8 +785,8 @@ export function OrdersClient({ customerOptions, employeeOptions, productOptions 
           />
           <TableBody>
             {sortedItems.map((o, idx) => {
-              const wf = workflowFromBackend(o.status, o.paymentStatus);
-              const isTerminal = wf === "COMPLETED" || wf === "CANCELLED";
+              const wf = workflowFromBackend(o.status, o.paymentStatus, o.workflowStatus);
+              const isTerminal = TERMINAL_WORKFLOW_SET.has(wf);
               return (
                 <TableRow
                   key={o.id}
@@ -826,20 +857,28 @@ export function OrdersClient({ customerOptions, employeeOptions, productOptions 
                     </Tooltip>
                   </TableCell>
                   <TableCell sx={{ width: 120 }}>
-                    <Tooltip
-                      title={
-                        WORKFLOW_STATUS_OPTIONS.find(
-                          (x) => x.value === workflowFromBackend(o.status, o.paymentStatus),
-                        )?.label || o.status
-                      }
-                      arrow
-                    >
-                      <span>
-                        {WORKFLOW_STATUS_OPTIONS.find(
-                          (x) => x.value === workflowFromBackend(o.status, o.paymentStatus),
-                        )?.label || o.status}
-                      </span>
-                    </Tooltip>
+                    <Stack direction="row" spacing={0.5} alignItems="center">
+                      <Tooltip
+                        title={
+                          WORKFLOW_STATUS_OPTIONS.find(
+                            (x) => x.value === wf,
+                          )?.label || o.status
+                        }
+                        arrow
+                      >
+                        <span>
+                          {
+                            WORKFLOW_STATUS_OPTIONS.find((x) => x.value === wf)?.label ||
+                            o.status
+                          }
+                        </span>
+                      </Tooltip>
+                      {o.autoApprovedBySystem && (
+                        <Tooltip title="ระบบอนุมัติอัตโนมัติ" arrow>
+                          <Chip size="small" color="secondary" label="AUTO" sx={{ height: 22 }} />
+                        </Tooltip>
+                      )}
+                    </Stack>
                   </TableCell>
                   <TableCell sx={{ width: 140 }}>
                     <Tooltip
@@ -874,21 +913,11 @@ export function OrdersClient({ customerOptions, employeeOptions, productOptions 
                           </Tooltip>
                         )}
                         {!isTerminal && canEdit && (
-                          <Tooltip
-                            title={
-                              workflowFromBackend(o.status, o.paymentStatus) === "COMPLETED"
-                                ? "แก้ไขไม่ได้ (เสร็จสิ้น)"
-                                : "แก้ไข"
-                            }
-                            arrow
-                          >
+                          <Tooltip title="แก้ไข" arrow>
                             <span>
                               <IconButton
                                 size="small"
                                 color="secondary"
-                                disabled={
-                                  workflowFromBackend(o.status, o.paymentStatus) === "COMPLETED"
-                                }
                                 onClick={() => router.push(`/dashboard/sales/orders/${o.id}/edit`)}
                               >
                                 <EditOutlinedIcon fontSize="small" />

--- a/app/dashboard/sales/orders/types.ts
+++ b/app/dashboard/sales/orders/types.ts
@@ -51,6 +51,7 @@ export type OrderFormInitial = {
   shipPostalCode?: string;
   status: string;
   paymentStatus: string;
+  workflowStatus?: string;
   shippingFee: number | "";
   otherCharges: number | "";
   orderDiscount: number | "";
@@ -61,4 +62,9 @@ export type OrderFormInitial = {
   items: OrderItemInput[];
   rejectReason?: string;
   cancelReason?: string;
+  upfrontPaymentPercent?: number | string;
+  autoApprovedBySystem?: boolean;
+  shippingUpdateCount?: number;
+  shippingLocked?: boolean;
+  creditEvaluationNote?: string;
 };

--- a/lib/sale-order-stock.ts
+++ b/lib/sale-order-stock.ts
@@ -1,0 +1,122 @@
+import { Prisma } from "@prisma/client";
+
+type Tx = Prisma.TransactionClient;
+
+type OrderWithItems = {
+  id: string;
+  shippingDate: Date | null;
+  items: Array<{
+    id: string;
+    productId: string | null;
+    qty: number | null;
+  }>;
+};
+
+export async function releaseOrderReservations(tx: Tx, saleOrderId: string) {
+  const reservations = await tx.saleOrderStockReservation.findMany({
+    where: { saleOrderId, releasedAt: null, deletedAt: null },
+  });
+
+  for (const reservation of reservations) {
+    if (!reservation.stockId) continue;
+    const stock = await tx.stock.findUnique({
+      where: { id: reservation.stockId },
+      select: { qtyReserved: true, productId: true },
+    });
+    const currentReserved = Number(stock?.qtyReserved ?? 0);
+    const qty = Math.max(0, Math.floor(Number(reservation.qty ?? 0)));
+    const releaseQty = Math.min(currentReserved, qty);
+    if (releaseQty > 0) {
+      await tx.stock.update({
+        where: { id: reservation.stockId },
+        data: { qtyReserved: { decrement: releaseQty } },
+      });
+      await tx.stockMovement.create({
+        data: {
+          stockId: reservation.stockId,
+          productId: stock?.productId as string,
+          saleOrderId,
+          type: "RELEASE",
+          qty: releaseQty,
+        },
+      });
+    }
+    await tx.saleOrderStockReservation.update({
+      where: { id: reservation.id },
+      data: { releasedAt: new Date() },
+    });
+  }
+}
+
+export async function applyStockForOrder(tx: Tx, order: OrderWithItems) {
+  const shippingDate = order.shippingDate ? new Date(order.shippingDate) : null;
+  const issueImmediately = Boolean(shippingDate);
+
+  for (const item of order.items) {
+    if (!item?.productId) continue;
+    let remaining = Math.max(0, Math.floor(Number(item.qty ?? 0)));
+    if (!Number.isFinite(remaining) || remaining <= 0) continue;
+
+    const stocks = await tx.stock.findMany({
+      where: { productId: item.productId, deletedAt: null },
+      orderBy: [
+        { expDate: "asc" },
+        { mfgDate: "asc" },
+        { createdAt: "asc" },
+      ],
+    });
+
+    for (const stock of stocks) {
+      if (remaining <= 0) break;
+      const onHand = Number(stock.qtyOnHand ?? 0);
+      const reserved = Number(stock.qtyReserved ?? 0);
+      const available = Math.max(0, issueImmediately ? onHand : onHand - reserved);
+      if (available <= 0) continue;
+      const allocation = Math.min(available, remaining);
+      if (allocation <= 0) continue;
+
+      if (issueImmediately) {
+        await tx.stock.update({
+          where: { id: stock.id },
+          data: { qtyOnHand: { decrement: allocation } },
+        });
+        await tx.stockMovement.create({
+          data: {
+            stockId: stock.id,
+            productId: stock.productId,
+            saleOrderId: order.id,
+            type: "ISSUE",
+            qty: allocation,
+          },
+        });
+      } else {
+        await tx.stock.update({
+          where: { id: stock.id },
+          data: { qtyReserved: { increment: allocation } },
+        });
+        await tx.saleOrderStockReservation.create({
+          data: {
+            saleOrderId: order.id,
+            stockId: stock.id,
+            qty: allocation,
+          },
+        });
+        await tx.stockMovement.create({
+          data: {
+            stockId: stock.id,
+            productId: stock.productId,
+            saleOrderId: order.id,
+            type: "RESERVE",
+            qty: allocation,
+          },
+        });
+      }
+      remaining -= allocation;
+    }
+  }
+}
+
+export async function rebuildOrderStockCommit(tx: Tx, order: OrderWithItems) {
+  await releaseOrderReservations(tx, order.id);
+  await applyStockForOrder(tx, order);
+}

--- a/lib/sales-approval.ts
+++ b/lib/sales-approval.ts
@@ -1,0 +1,130 @@
+import {
+  PaymentCondition,
+  SaleOrderStatus,
+  SaleOrderWorkflowStatus,
+} from "@prisma/client";
+
+const DEFAULT_AUTO_APPROVE_MAX_AMOUNT = Number(
+  process.env.SALES_AUTO_APPROVE_MAX_AMOUNT ?? 100000,
+);
+const DEFAULT_AUTO_APPROVE_MAX_PERCENT = Number(
+  process.env.SALES_AUTO_APPROVE_MAX_PERCENT ?? 30,
+);
+
+export type EvaluateWorkflowInput = {
+  paymentCondition: PaymentCondition;
+  grandTotal: number;
+  upfrontPaymentPercent?: number | null;
+  creditLimit?: number | null;
+  relationshipScore?: number | null;
+};
+
+export type EvaluateWorkflowResult = {
+  workflowStatus: SaleOrderWorkflowStatus;
+  baseStatus: SaleOrderStatus;
+  autoApprovedBySystem: boolean;
+  creditEvaluationNote?: string;
+};
+
+export function mapWorkflowStatusToBaseStatus(
+  workflow: SaleOrderWorkflowStatus,
+): SaleOrderStatus {
+  switch (workflow) {
+    case "WAITING_MANAGER_APPROVAL":
+    case "WAITING_CREDIT_EXTENSION":
+      return "CONFIRMED";
+    case "WAITING_PAYMENT_CONFIRMATION":
+    case "AUTO_APPROVED":
+    case "APPROVED":
+    case "PENDING_SHIPMENT":
+      return "APPROVED";
+    case "SHIPPED":
+      return "SHIPPED";
+    case "REJECTED":
+    case "EXPIRED":
+    case "CANCELLED":
+      return "CANCELLED";
+    default:
+      return "DRAFT";
+  }
+}
+
+export function evaluateSaleOrderWorkflow(
+  input: EvaluateWorkflowInput,
+): EvaluateWorkflowResult {
+  const {
+    paymentCondition,
+    grandTotal,
+    upfrontPaymentPercent = 0,
+    creditLimit,
+    relationshipScore,
+  } = input;
+
+  let workflowStatus: SaleOrderWorkflowStatus = "DRAFT";
+  let autoApprovedBySystem = false;
+  let note: string | undefined;
+
+  if (paymentCondition === "PREPAID") {
+    workflowStatus = "WAITING_MANAGER_APPROVAL";
+    note = "PREPAID: awaiting sales manager approval.";
+  } else {
+    if (typeof creditLimit === "number" && !Number.isNaN(creditLimit)) {
+      if (grandTotal <= creditLimit) {
+        workflowStatus = "WAITING_MANAGER_APPROVAL";
+        note = `เครดิตเพียงพอ วงเงินคงเหลือ ${creditLimit.toLocaleString()}`;
+      } else {
+        const maxAmount =
+          Number.isFinite(DEFAULT_AUTO_APPROVE_MAX_AMOUNT) &&
+          DEFAULT_AUTO_APPROVE_MAX_AMOUNT > 0
+            ? DEFAULT_AUTO_APPROVE_MAX_AMOUNT
+            : 100000;
+        const maxPercent =
+          Number.isFinite(DEFAULT_AUTO_APPROVE_MAX_PERCENT) &&
+          DEFAULT_AUTO_APPROVE_MAX_PERCENT >= 0
+            ? DEFAULT_AUTO_APPROVE_MAX_PERCENT
+            : 30;
+
+        if (grandTotal <= maxAmount && upfrontPaymentPercent <= maxPercent) {
+          workflowStatus = "AUTO_APPROVED";
+          autoApprovedBySystem = true;
+          note =
+            "ระบบอนุมัติอัตโนมัติ: วงเงินไม่เกินเกณฑ์และเปอร์เซ็นต์ชำระเงินอยู่ในช่วงที่กำหนด";
+        } else {
+          workflowStatus = "WAITING_CREDIT_EXTENSION";
+          note =
+            relationshipScore && relationshipScore < 3
+              ? "เครดิตไม่เพียงพอ คะแนนความสัมพันธ์ต่ำ ต้องขอเพิ่มวงเงิน"
+              : "เครดิตไม่เพียงพอ ต้องให้ธุรการขายดำเนินการขอเพิ่มวงเงิน";
+        }
+      }
+    } else {
+      // ไม่มีข้อมูลเครดิต ให้ผู้จัดการตรวจสอบ
+      workflowStatus = "WAITING_MANAGER_APPROVAL";
+      note = "ไม่พบวงเงินเครดิตลูกค้า ส่งให้ผู้จัดการตรวจสอบ";
+    }
+  }
+
+  const baseStatus = mapWorkflowStatusToBaseStatus(workflowStatus);
+
+  return {
+    workflowStatus,
+    baseStatus,
+    autoApprovedBySystem,
+    creditEvaluationNote: note,
+  };
+}
+
+export function shouldCommitStock(
+  workflowStatus: SaleOrderWorkflowStatus,
+): boolean {
+  switch (workflowStatus) {
+    case "WAITING_PAYMENT_CONFIRMATION":
+    case "AUTO_APPROVED":
+    case "APPROVED":
+    case "PENDING_SHIPMENT":
+    case "SHIPPED":
+      return true;
+    default:
+      return false;
+  }
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -102,6 +102,21 @@ enum PaymentCondition {
   POSTPAID // ส่งของก่อน
 }
 
+// Detailed workflow status for sale order approval + fulfillment
+enum SaleOrderWorkflowStatus {
+  DRAFT
+  WAITING_MANAGER_APPROVAL
+  WAITING_PAYMENT_CONFIRMATION
+  WAITING_CREDIT_EXTENSION
+  AUTO_APPROVED
+  APPROVED
+  REJECTED
+  EXPIRED
+  PENDING_SHIPMENT
+  SHIPPED
+  CANCELLED
+}
+
 // Quote enums
 enum QuoteStatus {
   DRAFT
@@ -677,6 +692,14 @@ model SaleOrder {
   shipTo        String?
   status        SaleOrderStatus @default(DRAFT)
   paymentStatus PaymentStatus   @default(UNPAID)
+  workflowStatus SaleOrderWorkflowStatus @default(DRAFT)
+  autoApprovedBySystem Boolean @default(false)
+  upfrontPaymentPercent Float  @default(0)
+  creditEvaluationNote  String?
+
+  shippingUpdateCount Int      @default(0)
+  shippingLocked      Boolean  @default(false)
+  expiresAt           DateTime?
 
   // Approval metadata
   approvedAt       DateTime?
@@ -716,6 +739,7 @@ model SaleOrder {
   @@index([customerId])
   @@index([salespersonId])
   @@index([approvedByUserId])
+  @@index([workflowStatus])
 }
 
 model SaleOrderItem {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -64,6 +64,7 @@ function buildPermissionGroup(resource: string, actions: PermissionAction[]) {
 const approvalActions: PermissionAction[] = ["approve", "reject"];
 const manageActions: PermissionAction[] = ["view", "create", "edit", "delete", ...approvalActions];
 const contributeActions: PermissionAction[] = ["view", "create", "edit"];
+const operationsActions: PermissionAction[] = ["view", "create", "edit", ...approvalActions];
 const viewOnly: PermissionAction[] = ["view"];
 const viewCreateActions: PermissionAction[] = ["view", "create"];
 
@@ -104,6 +105,18 @@ const roleSeeds: RoleSeed[] = [
       ...buildPermissionGroup("sales", viewCreateActions),
       // Visibility scope: staff sees own
       "sales_scope:own",
+    ],
+  },
+  {
+    key: "sales_operations",
+    name: "ธุรการฝ่ายขาย",
+    description: "ตรวจสอบการชำระเงินและประสานงานการจัดส่ง",
+    permissions: [
+      ...buildPermissionGroup("customers", contributeActions),
+      ...buildPermissionGroup("sales", operationsActions),
+      ...buildPermissionGroup("products", viewOnly),
+      // Visibility scope: operations see department-level data
+      "sales_scope:department",
     ],
   },
 ];
@@ -149,6 +162,20 @@ const userSeeds: UserSeed[] = [
       department: "การขาย",
       phone: "0810000003",
       startDate: new Date("2024-06-01"),
+    },
+  },
+  {
+    email: "sales.admin@csone.local",
+    name: "ธุรการฝ่ายขาย",
+    password: "SalesAdmin@123",
+    role: "USER",
+    roleKey: "sales_operations",
+    employee: {
+      employeeCode: "EMP-0004",
+      position: "ธุรการฝ่ายขาย",
+      department: "การขาย",
+      phone: "0810000004",
+      startDate: new Date("2024-07-01"),
     },
   },
 ];


### PR DESCRIPTION
## Summary
- add shared helpers for evaluating sale order workflow decisions and reserving/releasing stock
- wire the new workflow states into sales order CRUD APIs and persist auto-approval metadata
- update the dashboard order form/list to drive the workflow field, show auto approvals, and seed dedicated sales-operations credentials

## Testing
- pnpm lint *(fails: pre-existing lint errors across unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_69097e082ee0832393bd27b1ab275e61